### PR TITLE
Add VC6 project file and SUPERTINY flag

### DIFF
--- a/libchardet/chardet_vc6.dsp
+++ b/libchardet/chardet_vc6.dsp
@@ -1,0 +1,334 @@
+# Microsoft Developer Studio Project File - Name="chardet_vc6" - Package Owner=<4>
+# Microsoft Developer Studio Generated Build File, Format Version 6.00
+# ** DO NOT EDIT **
+
+# TARGTYPE "Win32 (x86) Dynamic-Link Library" 0x0102
+
+CFG=chardet_vc6 - Win32 Release
+!MESSAGE This is not a valid makefile. To build this project using NMAKE,
+!MESSAGE use the Export Makefile command and run
+!MESSAGE 
+!MESSAGE NMAKE /f "chardet_vc6.mak".
+!MESSAGE 
+!MESSAGE You can specify a configuration when running NMAKE
+!MESSAGE by defining the macro CFG on the command line. For example:
+!MESSAGE 
+!MESSAGE NMAKE /f "chardet_vc6.mak" CFG="chardet_vc6 - Win32 Release"
+!MESSAGE 
+!MESSAGE Possible choices for configuration are:
+!MESSAGE 
+!MESSAGE "chardet_vc6 - Win32 Release" (based on "Win32 (x86) Dynamic-Link Library")
+!MESSAGE "chardet_vc6 - Win32 Debug" (based on "Win32 (x86) Dynamic-Link Library")
+!MESSAGE 
+
+# Begin Project
+# PROP AllowPerConfigDependencies 0
+# PROP Scc_ProjName ""
+# PROP Scc_LocalPath ""
+CPP=cl.exe
+MTL=midl.exe
+RSC=rc.exe
+
+!IF  "$(CFG)" == "chardet_vc6 - Win32 Release"
+
+# PROP BASE Use_MFC 0
+# PROP BASE Use_Debug_Libraries 0
+# PROP BASE Output_Dir ".\chardet_"
+# PROP BASE Intermediate_Dir ".\chardet_"
+# PROP BASE Target_Dir ""
+# PROP Use_MFC 0
+# PROP Use_Debug_Libraries 0
+# PROP Output_Dir ".\Release"
+# PROP Intermediate_Dir ".\Release"
+# PROP Ignore_Export_Lib 0
+# PROP Target_Dir ""
+# ADD BASE CPP /nologo /MT /W3 /GX /O2 /D "WIN32" /D "NDEBUG" /D "_WINDOWS" /YX /c
+# ADD CPP /nologo /Zp4 /MT /W3 /Ox /Ot /Oa /Og /Oi /Ob2 /Gf /Gy /I ".\src" /I ".\src\tables" /D "NDEBUG" /D "WIN32" /D "_WINDOWS" /D "DLL_EXPORTS" /D "SUPERTINY" /YX /FD /c
+# SUBTRACT CPP /Os
+# ADD BASE MTL /nologo /D "NDEBUG" /win32
+# ADD MTL /nologo /D "NDEBUG" /mktyplib203 /win32
+# ADD BASE RSC /l 0x411 /d "NDEBUG"
+# ADD RSC /l 0x411 /d "NDEBUG"
+BSC32=bscmake.exe
+# ADD BASE BSC32 /nologo
+# ADD BSC32 /nologo
+LINK32=link.exe
+# ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:windows /dll /machine:I386
+# ADD LINK32 kernel32.lib /nologo /entry:"DllMain" /subsystem:windows /dll /machine:I386 /nodefaultlib /out:".\Release\chardet.dll" /filealign:512 /OPT:REF /OPT:ICF,20 /LARGEADDRESSAWARE
+# SUBTRACT LINK32 /pdb:none /map
+
+!ELSEIF  "$(CFG)" == "chardet_vc6 - Win32 Debug"
+
+# PROP BASE Use_MFC 0
+# PROP BASE Use_Debug_Libraries 1
+# PROP BASE Output_Dir ".\Debug"
+# PROP BASE Intermediate_Dir ".\Debug"
+# PROP BASE Target_Dir ""
+# PROP Use_MFC 0
+# PROP Use_Debug_Libraries 1
+# PROP Output_Dir ".\Debug"
+# PROP Intermediate_Dir ".\Debug"
+# PROP Ignore_Export_Lib 0
+# PROP Target_Dir ""
+# ADD BASE CPP /nologo /MTd /W3 /Gm /GX /Zi /Od /D "WIN32" /D "_DEBUG" /D "_WINDOWS" /YX /c
+# ADD CPP /nologo /MTd /W3 /Gm /GX /ZI /Od /I ".\src" /I ".\src\tables" /D "_DEBUG" /D "WIN32" /D "_WINDOWS" /D "DLL_EXPORTS" /YX /FD /c
+# ADD BASE MTL /nologo /D "_DEBUG" /win32
+# ADD MTL /nologo /D "_DEBUG" /mktyplib203 /win32
+# ADD BASE RSC /l 0x411 /d "_DEBUG"
+# ADD RSC /l 0x411 /d "_DEBUG"
+BSC32=bscmake.exe
+# ADD BASE BSC32 /nologo
+# ADD BSC32 /nologo
+LINK32=link.exe
+# ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:windows /dll /debug /machine:I386
+# ADD LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:windows /dll /debug /machine:I386 /out:".\Debug\chardet.dll"
+# SUBTRACT LINK32 /profile /nodefaultlib
+
+!ENDIF 
+
+# Begin Target
+
+# Name "chardet_vc6 - Win32 Release"
+# Name "chardet_vc6 - Win32 Debug"
+# Begin Group "Source Files"
+
+# PROP Default_Filter "cpp;c;cxx;rc;def;r;odl;idl;hpj;bat;for;f90"
+# Begin Source File
+
+SOURCE=.\src\chardet.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\CharDistribution.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\CharDistribution.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\entry\impl.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\JpCntx.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\JpCntx.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\LangArabicModel.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\LangBulgarianModel.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\LangCyrillicModel.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\LangDanishModel.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\LangEsperantoModel.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\LangFrenchModel.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\LangGermanModel.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\LangGreekModel.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\LangHebrewModel.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\LangHungarianModel.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\LangSpanishModel.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\LangThaiModel.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\LangTurkishModel.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\LangVietnameseModel.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\nsBig5Prober.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\nsBig5Prober.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\nsCharSetProber.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\nsCharSetProber.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\nsCodingStateMachine.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\nscore.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\nsEscCharsetProber.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\nsEscCharsetProber.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\nsEscSM.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\nsEUCJPProber.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\nsEUCJPProber.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\nsEUCKRProber.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\nsEUCKRProber.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\nsEUCTWProber.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\nsEUCTWProber.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\nsGB2312Prober.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\nsGB2312Prober.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\nsHebrewProber.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\nsHebrewProber.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\nsLatin1Prober.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\nsLatin1Prober.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\nsMBCSGroupProber.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\nsMBCSGroupProber.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\nsMBCSSM.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\nsPkgInt.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\nsSBCharSetProber.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\nsSBCharSetProber.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\nsSBCSGroupProber.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\nsSBCSGroupProber.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\nsSJISProber.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\nsSJISProber.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\nsUniversalDetector.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\nsUniversalDetector.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\nsUTF8Prober.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\nsUTF8Prober.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\prmem.h
+# End Source File
+# End Group
+# Begin Group "Header Files"
+
+# PROP Default_Filter "h;hpp;hxx;hm;inl;fi;fd"
+# End Group
+# Begin Group "Resource Files"
+
+# PROP Default_Filter "ico;cur;bmp;dlg;rc2;rct;bin;cnt;rtf;gif;jpg;jpeg;jpe"
+# Begin Source File
+
+SOURCE=.\rc\chardet.rc
+# End Source File
+# End Group
+# End Target
+# End Project

--- a/libchardet/chardet_vc6.dsw
+++ b/libchardet/chardet_vc6.dsw
@@ -1,0 +1,29 @@
+Microsoft Developer Studio Workspace File, Format Version 6.00
+# WARNING: DO NOT EDIT OR DELETE THIS WORKSPACE FILE!
+
+###############################################################################
+
+Project: "chardet_vc6"=".\chardet_vc6.dsp" - Package Owner=<4>
+
+Package=<5>
+{{{
+}}}
+
+Package=<4>
+{{{
+}}}
+
+###############################################################################
+
+Global:
+
+Package=<5>
+{{{
+}}}
+
+Package=<3>
+{{{
+}}}
+
+###############################################################################
+

--- a/libchardet/rc/chardet.rc
+++ b/libchardet/rc/chardet.rc
@@ -1,0 +1,37 @@
+#ifndef _MAC
+/////////////////////////////////////////////////////////////////////////////
+//
+// Version
+//
+#define VS_VERSION_INFO 1
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION 1,9,2,1
+ PRODUCTVERSION 1,9,2,1
+ FILEFLAGSMASK 0x3fL
+ FILEFLAGS 0x0L
+ FILEOS 0x40004L
+ FILETYPE 0x2L
+ FILESUBTYPE 0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "04090000"
+        BEGIN
+            VALUE "Comments""\0"
+            VALUE "CompanyName", "Mozilla\0"
+            VALUE "FileDescription", "Chardet\0"
+            VALUE "FileVersion", "1.9.2.1\0"
+            VALUE "InternalName", "chardet\0"
+            VALUE "LegalCopyright", "Copyright © 1998\0"
+            VALUE "LegalTrademarks", "\0"
+            VALUE "OriginalFilename", "chardet.dll\0"
+            VALUE "ProductVersion", "1.9.2.1\0"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 0
+    END
+END
+
+#endif    // !_MAC

--- a/libchardet/src/chardet.h
+++ b/libchardet/src/chardet.h
@@ -39,6 +39,11 @@
 #define ___CHARDET_H___
 
 #ifdef _WIN32
+#   ifdef SUPERTINY
+	extern "C" int  _purecall(){return 0;} 
+	extern "C" int  _fltused=0;
+#   endif
+
 #   ifdef DLL_EXPORTS
 #	define CHARDET_IMEXPORT extern _declspec(dllexport)
 #   elif defined(STATICLIB)

--- a/libchardet/src/entry/impl.cpp
+++ b/libchardet/src/entry/impl.cpp
@@ -45,7 +45,24 @@
 #include <stdlib.h>
 
 #ifdef _WIN32
+
 #   include <windows.h>
+#   ifdef SUPERTINY
+	static char *strcpyL(char *dest, const char *in)
+	{
+		char *ret = dest;
+		while ((*dest++ = *in++));
+		return ret;
+	}
+	#define strcpy strcpyL
+	static char *strdupL(const char *s)
+	{
+		char *d = new char[strlen(s)+1];
+		strcpyL(d,s);
+		return d;
+	}
+	#define strdup strdupL
+#   endif //SUPERTINY
 #endif
 
 

--- a/libchardet/src/prmem.h
+++ b/libchardet/src/prmem.h
@@ -39,11 +39,29 @@
 
 #include <stdlib.h>
 
-inline void* PR_Malloc(size_t len)
-{
-    return malloc(len);
-}
-
 #define PR_FREEIF(p) do { if (p) delete p; } while(0)
+
+#if defined(WIN32) && defined(SUPERTINY)
+	#include <windows.h>
+	inline void* __cdecl operator new(size_t siz)
+	{
+		return ::HeapAlloc(GetProcessHeap(), 0, siz);
+	}
+	inline void __cdecl operator delete(void* ptr)
+	{
+		::HeapFree(GetProcessHeap(), 0, ptr);
+	}
+	inline void* PR_Malloc(size_t len)
+	{
+	    return ::HeapAlloc(GetProcessHeap(), 0, len);
+	}
+
+#else // WIN32+SUPERTINY
+	inline void* PR_Malloc(size_t len)
+	{
+	    return malloc(len);
+	}
+#endif
+
 
 #endif


### PR DESCRIPTION
The idea is to compile with /nodefaultlib to have a smaller dll file.

1) Add a SUPERTINY flag to override new, delete, operators, as well as strdup() and a few others.
2) Make a resource file in order to have nice versioning in the dll file (helpful for end user). I hate untagged exe/dll files.
3) Make a VC6 project file (I mostly use VC6) also the code is more optimized and we can easily use /nodefaultlib alsod isabling C++ exception handling.

Note that I just copy/pasted the VC4 project file and made a couple changes.
The advantage is also that this VC6 build can run on old NT3.x and Win32s without issues.
Hopefully it will work for you
Probably even newer versions of VC could be used but I did not try.
