### PR TITLE
[libchardet] Ensure malloc is fred with free (PR_Malloc/PR_Free)

### DIFF
--- a/libchardet/src/entry/impl.cpp
+++ b/libchardet/src/entry/impl.cpp
@@ -45,9 +45,17 @@
 #include <stdlib.h>
 
 #ifdef _WIN32
-
 #   include <windows.h>
-#   ifdef SUPERTINY
+
+	#ifdef SUPERTINY
+	static size_t strlenL(const char *str)
+	{
+		size_t len=0;
+		while(str[len])
+			len++;
+		return len;
+	}
+	#define strlen strlenL
 	static char *strcpyL(char *dest, const char *in)
 	{
 		char *ret = dest;
@@ -55,15 +63,17 @@
 		return ret;
 	}
 	#define strcpy strcpyL
-	static char *strdupL(const char *s)
-	{
-		char *d = new char[strlen(s)+1];
-		strcpyL(d,s);
-		return d;
-	}
-	#define strdup strdupL
-#   endif //SUPERTINY
-#endif
+	#endif // SUPERTINY
+
+#endif // _WIN32
+
+// Use our own strdup that uses the new operator
+static char *strdupNew(const char *s)
+{
+	char *d = new char[strlen(s)+1];
+	strcpy(d,s);
+	return d;
+}
 
 
 #ifdef _MANAGED
@@ -90,13 +100,13 @@ public:
 
     virtual void Report(const char* charset)
     {
-	charset_ = strdup(charset);
+	charset_ = strdupNew(charset);
     }
 
     virtual void Reset()
     {
 	nsUniversalDetector::Reset();
-	charset_ = strdup("");
+	charset_ = strdupNew("");
     }
 
     const char* GetCharset() const


### PR DESCRIPTION
There is a problem with handling of mem, the original code uses PR_Malloc = malloc and then the memory is freed with PR_FREEIF that is defined as `delete`. This is not actually correct, a `malloc()` should be freed using `free()` only.

This patch fixes that.
There is also a problem with `strdup()` that is freed with `delete` in `impl.cpp`, ~~I am not exactly sure what to do about this yet.~~
EDIT: I just replaced the calls to `strdup()` by calls to `strdupNew()` that duplicates the string using the `new` operator.

I also Added the `USE_LOCALALLOC` flag to allow working on Windows NT3.10.340 beta with the `SUPERTINY` flag.